### PR TITLE
fix go vet complaining about uintptr misuse

### DIFF
--- a/glib/gasyncresult.go
+++ b/glib/gasyncresult.go
@@ -82,7 +82,7 @@ func (v *AsyncResult) GetSourceObject() *Object {
 }
 
 // IsTagged is a wrapper around g_async_result_is_tagged
-func (v *AsyncResult) IsTagged(sourceTag uintptr) bool {
+func (v *AsyncResult) IsTagged(sourceTag unsafe.Pointer) bool {
 	c := C.g_async_result_is_tagged(v.native(), C.gpointer(sourceTag))
 	return gobool(c)
 }


### PR DESCRIPTION
Removes go vet warning.

Essentially this is a breaking change in terms of API compatibility, but it was more broken before, so I'll release it as a patch version