### PR TITLE
remove global signal and closure maps in favor of runtime/cgo.Handle

### DIFF
--- a/glib/glib.go
+++ b/glib/glib.go
@@ -30,7 +30,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
-	"sync"
+	"runtime/cgo"
 	"unsafe"
 )
 
@@ -59,20 +59,6 @@ type closureContext struct {
 
 var (
 	errNilPtr = errors.New("cgo returned unexpected nil pointer")
-
-	closures = struct {
-		sync.RWMutex
-		m map[*C.GClosure]closureContext
-	}{
-		m: make(map[*C.GClosure]closureContext),
-	}
-
-	signals = struct {
-		sync.RWMutex
-		m map[SignalHandle]*C.GClosure
-	}{
-		m: make(map[SignalHandle]*C.GClosure),
-	}
 )
 
 /*
@@ -196,14 +182,18 @@ const (
 // not run.
 //
 //export goMarshal
-func goMarshal(closure *C.GClosure, retValue *C.GValue,
-	nParams C.guint, params *C.GValue,
-	invocationHint C.gpointer, marshalData *C.GValue) {
-
+func goMarshal(
+	closure *C.GClosure,
+	retValue *C.GValue,
+	nParams C.guint,
+	params *C.GValue,
+	invocationHint C.gpointer,
+	marshalData C.gpointer,
+) {
 	// Get the context associated with this callback closure.
-	closures.RLock()
-	cc := closures.m[closure]
-	closures.RUnlock()
+	ccHandle := cgo.Handle(*(*C.guint)(marshalData))
+
+	cc := ccHandle.Value().(*closureContext)
 
 	// Get number of parameters passed in.  If user data was saved with the
 	// closure context, increment the total number of parameters.
@@ -351,9 +341,6 @@ func sourceAttach(src *C.struct__GSource, rf reflect.Value, args ...interface{})
 	// always be a function.
 	var closure *C.GClosure
 	closure, _ = ClosureNew(rf.Interface(), args...)
-
-	// Remove closure context when closure is finalized.
-	C._g_closure_add_finalize_notifier(closure)
 
 	// Set closure to run as a callback when the idle source runs.
 	C.g_source_set_closure(src, closure)

--- a/glib/gobject.go
+++ b/glib/gobject.go
@@ -317,16 +317,6 @@ func (v *Object) HandlerUnblock(handle SignalHandle) {
 // HandlerDisconnect is a wrapper around g_signal_handler_disconnect().
 func (v *Object) HandlerDisconnect(handle SignalHandle) {
 	C.g_signal_handler_disconnect(C.gpointer(v.GObject), C.gulong(handle))
-
-	signals.Lock()
-	closure := signals.m[handle]
-	C.g_closure_invalidate(closure)
-	delete(signals.m, handle)
-	signals.Unlock()
-
-	closures.Lock()
-	delete(closures.m, closure)
-	closures.Unlock()
 }
 
 // WithTransferOriginal can be used to capture an object from transfer-none


### PR DESCRIPTION
store the handle in the closure data and retrieve the value in goMarshal

fix a use after free bug while disconnecting signals

fixes https://github.com/go-gst/go-gst/issues/94