### PR TITLE
add ArbitraryValue as a GValueTransformer

### DIFF
--- a/glib/glib.go.h
+++ b/glib/glib.go.h
@@ -193,4 +193,25 @@ static inline gchar **next_gcharptr(gchar **s) { return (s + 1); }
 extern void goCompareDataFuncs(gconstpointer a, gconstpointer b,
                                gpointer user_data);
 
+
+/**
+ * custom glib type for arbitrary go data
+ */
+
+#define GLIB_GO_TYPE_ARBITRARY_DATA (glib_go_arbitrary_data_get_type())
+
+typedef struct
+{
+  guint data; // Arbitrary data, corresponds to an uintptr in Go
+} GlibGoArbitraryData;
+
+GType glib_go_arbitrary_data_get_type(void);
+
+static GlibGoArbitraryData *glib_go_arbitrary_data_new(guint data);
+static GlibGoArbitraryData *glib_go_arbitrary_data_copy (GlibGoArbitraryData * orig);
+
+/**
+ * end custom glib type for arbitrary go data
+ */
+
 #endif

--- a/glib/go_boxed.go
+++ b/glib/go_boxed.go
@@ -1,0 +1,88 @@
+package glib
+
+/*
+#include "glib.go.h"
+
+G_DEFINE_BOXED_TYPE(GlibGoArbitraryData, glib_go_arbitrary_data,
+                    glib_go_arbitrary_data_copy,
+                    g_free)
+
+static GlibGoArbitraryData *glib_go_arbitrary_data_copy (GlibGoArbitraryData * orig)
+{
+    GlibGoArbitraryData *copy;
+
+    if (!orig)
+        return NULL;
+
+    copy = g_new0 (GlibGoArbitraryData, 1);
+    copy->data = orig->data;
+
+    return copy;
+}
+
+static GlibGoArbitraryData *glib_go_arbitrary_data_new(guint data)
+{
+    GlibGoArbitraryData *gdata;
+
+    gdata = g_new0(GlibGoArbitraryData, 1);
+    gdata->data = data;
+
+    return gdata;
+}
+*/
+import "C"
+
+import (
+	"runtime/cgo"
+	"unsafe"
+)
+
+var TYPE_ARBITRARY_DATA Type = Type(C.GLIB_GO_TYPE_ARBITRARY_DATA)
+
+func init() {
+	tm := []TypeMarshaler{
+		{TYPE_ARBITRARY_DATA, marshalArbitraryValue},
+	}
+
+	RegisterGValueMarshalers(tm)
+}
+
+// ArbitraryValue allows to pass any value into a glib property or signal.
+//
+// it is helpful when you want to pass a go value into a custom element that is
+// also defined in go.
+type ArbitraryValue struct {
+	Data any
+}
+
+var _ ValueTransformer = ArbitraryValue{}
+
+func (v ArbitraryValue) ToGValue() (*Value, error) {
+	handle := cgo.NewHandle(v.Data)
+
+	gv, err := ValueInit(TYPE_ARBITRARY_DATA)
+
+	if err != nil {
+		return nil, err
+	}
+
+	cv := C.glib_go_arbitrary_data_new(C.guint(handle))
+
+	gv.TakeBoxed(unsafe.Pointer(cv))
+
+	return gv, nil
+}
+
+func marshalArbitraryValue(p unsafe.Pointer) (interface{}, error) {
+	cp := C.g_value_get_boxed((*C.GValue)(p))
+
+	cv := (*C.GlibGoArbitraryData)(cp)
+
+	handle := cgo.Handle(cv.data)
+
+	arb := ArbitraryValue{
+		Data: handle.Value(),
+	}
+
+	return arb, nil
+}

--- a/glib/go_boxed_test.go
+++ b/glib/go_boxed_test.go
@@ -1,0 +1,39 @@
+package glib_test
+
+import (
+	"testing"
+
+	"github.com/go-gst/go-glib/glib"
+)
+
+func TestArbitraryValue(t *testing.T) {
+	// Create a new ArbitraryValue
+	av := glib.ArbitraryValue{Data: 42}
+	// Convert it to a GValue
+	v, err := av.ToGValue()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	retI, err := v.GoValue()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ret, ok := retI.(glib.ArbitraryValue)
+
+	if !ok {
+		t.Fatalf("Expected ArbitraryValue, got %T", retI)
+	}
+
+	data, ok := ret.Data.(int)
+
+	if !ok {
+		t.Fatalf("Expected int, got %T", ret.Data)
+	}
+
+	if data != 42 {
+		t.Fatalf("Expected 42, got %v", ret.Data)
+	}
+}

--- a/glib/gobject.go
+++ b/glib/gobject.go
@@ -289,7 +289,8 @@ func (v *Object) Emit(s string, args ...interface{}) (interface{}, error) {
 		return nil, fmt.Errorf("%w for signal %s: expected %d, got %d", ErrSignalWrongNumberOfArgs, s, q.n_params, len(args))
 	}
 
-	return_type := Type(q.return_type)
+	// get the return type, remove the static scope flag first
+	return_type := Type(q.return_type &^ C.G_SIGNAL_TYPE_STATIC_SCOPE)
 
 	// Create array of this instance and arguments
 	valv := C.alloc_gvalue_list(C.int(len(args)) + 1)

--- a/glib/gvalue.go
+++ b/glib/gvalue.go
@@ -587,6 +587,11 @@ func (v *Value) SetBoxed(p unsafe.Pointer) {
 	C.g_value_set_boxed(v.native(), C.gconstpointer(p))
 }
 
+// TakeBoxed is a wrapper around g_value_take_boxed().
+func (v *Value) TakeBoxed(p unsafe.Pointer) {
+	C.g_value_take_boxed(v.native(), C.gconstpointer(p))
+}
+
 // GetPointer is a wrapper around g_value_get_pointer().
 func (v *Value) GetPointer() unsafe.Pointer {
 	return unsafe.Pointer(C.g_value_get_pointer(v.native()))


### PR DESCRIPTION
Register a new glib Type to support passing arbitrary go data. This is unsafe in the way that the types will not be checked when passing through cgo.

Resolves https://github.com/go-gst/go-gst/issues/120