### PR TITLE
Fix emit with void return glib critical assert

### DIFF
--- a/glib/gobject.go
+++ b/glib/gobject.go
@@ -314,7 +314,7 @@ func (v *Object) Emit(s string, args ...interface{}) (interface{}, error) {
 	// free the valv array after the values have been freed
 	defer C.g_free(C.gpointer(valv))
 
-	if return_type != TYPE_INVALID {
+	if return_type != TYPE_INVALID && return_type != TYPE_NONE {
 		// the return value must have the correct type set
 		ret, err := ValueInit(return_type)
 		if err != nil {


### PR DESCRIPTION
(__debug_bin234817696:1448477): GLib-GObject-CRITICAL **: 10:30:36.348: can't peek value table for type 'void' which is not currently referenced

(__debug_bin234817696:1448477): GLib-GObject-CRITICAL **: 10:30:36.348: ../../../gobject/gvalue.c:104: cannot initialize GValue with type 'void', this type has no GTypeValueTable implementation