### PR TITLE
correctly copy and free GlibGoArbitraryData

### DIFF
--- a/glib/glib.go.h
+++ b/glib/glib.go.h
@@ -209,6 +209,7 @@ GType glib_go_arbitrary_data_get_type(void);
 
 static GlibGoArbitraryData *glib_go_arbitrary_data_new(guint data);
 static GlibGoArbitraryData *glib_go_arbitrary_data_copy (GlibGoArbitraryData * orig);
+static void glib_go_arbitrary_data_free (GlibGoArbitraryData * orig);
 
 /**
  * end custom glib type for arbitrary go data

--- a/glib/go_boxed.go
+++ b/glib/go_boxed.go
@@ -3,9 +3,19 @@ package glib
 /*
 #include "glib.go.h"
 
+extern guint goCopyCgoHandle (guint handle);
+extern void  goFreeCgoHandle (guint handle);
+
 G_DEFINE_BOXED_TYPE(GlibGoArbitraryData, glib_go_arbitrary_data,
                     glib_go_arbitrary_data_copy,
-                    g_free)
+                    glib_go_arbitrary_data_free)
+
+static void glib_go_arbitrary_data_free (GlibGoArbitraryData * d)
+{
+	goFreeCgoHandle(d->data);
+
+	g_free(d);
+}
 
 static GlibGoArbitraryData *glib_go_arbitrary_data_copy (GlibGoArbitraryData * orig)
 {
@@ -15,7 +25,7 @@ static GlibGoArbitraryData *glib_go_arbitrary_data_copy (GlibGoArbitraryData * o
         return NULL;
 
     copy = g_new0 (GlibGoArbitraryData, 1);
-    copy->data = orig->data;
+    copy->data = goCopyCgoHandle(orig->data);
 
     return copy;
 }
@@ -68,6 +78,8 @@ func (v ArbitraryValue) ToGValue() (*Value, error) {
 
 	cv := C.glib_go_arbitrary_data_new(C.guint(handle))
 
+	// TakeBoxed lets the GValue take ownership of the boxed struct
+	// the gvalue will free the data when it is freed
 	gv.TakeBoxed(unsafe.Pointer(cv))
 
 	return gv, nil

--- a/glib/go_boxed_exports.go
+++ b/glib/go_boxed_exports.go
@@ -1,0 +1,27 @@
+package glib
+
+// CGO exports have to be defined in a separate file from where they are used or else
+// there will be double linkage issues.
+
+/*
+#cgo CFLAGS: -Wno-deprecated-declarations
+#include "glib.go.h"
+*/
+import "C"
+import "runtime/cgo"
+
+//export goCopyCgoHandle
+func goCopyCgoHandle(handle C.guint) C.guint {
+	h1 := cgo.Handle(handle)
+
+	h2 := cgo.NewHandle(h1.Value())
+
+	return C.guint(h2)
+}
+
+//export goFreeCgoHandle
+func goFreeCgoHandle(handle C.guint) {
+	h := cgo.Handle(handle)
+
+	h.Delete()
+}


### PR DESCRIPTION
The first version of `ArbitraryValue` leaked the go value by not ever deleting the handle. Letting the `GValue` take care of freeing the handle requires that also copying is implemented correctly.

Copying does a shallow copy of the go value.