### PR TITLE
handle int32 & uin32 gvalue

### DIFF
--- a/glib/gvalue.go
+++ b/glib/gvalue.go
@@ -178,6 +178,14 @@ func gValue(v interface{}) (gvalue *Value, err error) {
 		val.SetInt64(e)
 		return val, nil
 
+	case int32:
+		val, err := ValueInit(TYPE_INT)
+		if err != nil {
+			return nil, err
+		}
+		val.SetInt(int(e))
+		return val, nil
+
 	case int:
 		val, err := ValueInit(TYPE_INT)
 		if err != nil {
@@ -200,6 +208,14 @@ func gValue(v interface{}) (gvalue *Value, err error) {
 			return nil, err
 		}
 		val.SetUInt64(e)
+		return val, nil
+
+	case uint32:
+		val, err := ValueInit(TYPE_UINT)
+		if err != nil {
+			return nil, err
+		}
+		val.SetUInt(uint(e))
 		return val, nil
 
 	case uint:


### PR DESCRIPTION
Due to golang (u)int is specified to be at least 32 bits - it is safe to assume that (u)int32 can be casted into regular gvalue instead of throwing an exception. 

Use case - is integer atomics where we have to set an explicit integer size.

So I find that is not a good situation where we could easily cast int32 to int, but instead returning an error. I suggest applying these changes will make this wrapper lets say less hostile to the end user 