### PR TITLE
Fix potential dangling pointer in marshalObject

### DIFF
--- a/glib/gvalue.go
+++ b/glib/gvalue.go
@@ -495,7 +495,7 @@ func marshalPointer(p unsafe.Pointer) (interface{}, error) {
 
 func marshalObject(p unsafe.Pointer) (interface{}, error) {
 	c := C.g_value_get_object((*C.GValue)(p))
-	return newObject((*C.GObject)(c)), nil
+	return Take(unsafe.Pointer(c)), nil
 }
 
 func marshalVariant(p unsafe.Pointer) (interface{}, error) {


### PR DESCRIPTION
marshalObject returns a new Go object that holds a copy of the C GObject pointer retrieved from the GValue, but the reference count on the C GObject is not increased. The GValue created in GoValue() is no longer in scope after GoValue returns, and can be freed by the garbage collector. At this point, if no non-Go code holds a reference to the C GObject, then the C GObject reference count will drop to zero, the C GObject will be disposed, and the Go object pointer to it will become a dangling pointer.

Fix this by calling the `glib.Take` function in marshalObject. This increments the reference count for the C GObject, and adds a finaliser to the Go Object which will decrement the C reference count when the Go object is garbage collected.