### PR TITLE
add pprof.Profile for tracing active objects and closures

### DIFF
--- a/glib/connect.go
+++ b/glib/connect.go
@@ -97,6 +97,8 @@ func ClosureNew(f interface{}, marshalData ...interface{}) (*C.GClosure, error) 
 	// save the closure context in the closure itself
 	ccHandle := cgo.NewHandle(&cc)
 
+	closureProfile.Add(ccHandle, 2)
+
 	c := C._g_closure_new(C.guint(ccHandle))
 
 	C.g_closure_ref(c)
@@ -110,6 +112,8 @@ func ClosureNew(f interface{}, marshalData ...interface{}) (*C.GClosure, error) 
 //export removeClosure
 func removeClosure(data C.gpointer, closure *C.GClosure) {
 	ccHandle := cgo.Handle(*(*C.guint)(data))
+
+	closureProfile.Remove(ccHandle)
 
 	ccHandle.Delete()
 

--- a/glib/gobject.go
+++ b/glib/gobject.go
@@ -169,17 +169,20 @@ func ToGObject(p unsafe.Pointer) *C.GObject {
 
 // Ref is a wrapper around g_object_ref().
 func (v *Object) Ref() *Object {
+	gObjectProfile.Add(v, 1)
 	C.g_object_ref(C.gpointer(v.GObject))
 	return v
 }
 
 // Unref is a wrapper around g_object_unref().
 func (v *Object) Unref() {
+	gObjectProfile.Remove(v)
 	C.g_object_unref(C.gpointer(v.GObject))
 }
 
 // RefSink is a wrapper around g_object_ref_sink().
 func (v *Object) RefSink() {
+	gObjectProfile.Add(v, 1)
 	C.g_object_ref_sink(C.gpointer(v.GObject))
 }
 
@@ -191,6 +194,7 @@ func (v *Object) IsFloating() bool {
 
 // ForceFloating is a wrapper around g_object_force_floating().
 func (v *Object) ForceFloating() {
+	gObjectProfile.Remove(v)
 	C.g_object_force_floating(v.GObject)
 }
 

--- a/glib/trace.go
+++ b/glib/trace.go
@@ -1,0 +1,21 @@
+package glib
+
+import "runtime/pprof"
+
+var gObjectProfile *pprof.Profile
+var closureProfile *pprof.Profile
+
+func init() {
+	objects := "go-glib-reffed-objects"
+	gObjectProfile = pprof.Lookup(objects)
+	if gObjectProfile == nil {
+		gObjectProfile = pprof.NewProfile(objects)
+	}
+
+	closures := "go-glib-active-closures"
+	closureProfile = pprof.Lookup(closures)
+	if closureProfile == nil {
+		closureProfile = pprof.NewProfile(closures)
+	}
+
+}


### PR DESCRIPTION
this helps identifying memory leaks caused by the go program. We register two profiles to trace the references via pprof:

![image](https://github.com/user-attachments/assets/415e24e9-4369-47de-8f8a-2e3ec8add001)
