### PR TITLE
feat: add g_param_spec_uint binding

### DIFF
--- a/glib/gobject.go
+++ b/glib/gobject.go
@@ -211,7 +211,7 @@ func (v *Object) GetParamSpecUInt64(name string) (*ParamSpecUInt64, error) {
 		return nil, errors.New("couldn't find Property")
 	}
 
-	if Type(paramSpec.value_type) != TYPE_UINT {
+	if Type(paramSpec.value_type) != TYPE_UINT64 {
 		return nil, errors.New("Wrong property type")
 	}
 

--- a/glib/gobject.go
+++ b/glib/gobject.go
@@ -172,6 +172,52 @@ func (v *Object) Set(name string, value interface{}) error {
 	return v.SetProperty(name, value)
 }
 
+// GetParamSpec returns the ParamSpec of a property of the underlying GObject.
+func (v *Object) GetParamSpec(name string) (*ParamSpec, error) {
+	cstr := C.CString(name)
+	defer C.free(unsafe.Pointer(cstr))
+
+	paramSpec := C.g_object_class_find_property(C._g_object_get_class(v.native()), (*C.gchar)(cstr))
+	if paramSpec == nil {
+		return nil, errors.New("couldn't find Property")
+	}
+	return ToParamSpec((unsafe.Pointer)(paramSpec)), nil
+}
+
+// GetParamSpecUInt returns the ParamSpecUInt of a property of the underlying GObject.
+func (v *Object) GetParamSpecUInt(name string) (*ParamSpecUInt, error) {
+	cstr := C.CString(name)
+	defer C.free(unsafe.Pointer(cstr))
+
+	paramSpec := C.g_object_class_find_property(C._g_object_get_class(v.native()), (*C.gchar)(cstr))
+	if paramSpec == nil {
+		return nil, errors.New("couldn't find Property")
+	}
+
+	if Type(paramSpec.value_type) != TYPE_UINT {
+		return nil, errors.New("Wrong property type")
+	}
+
+	return ToParamSpecUInt((unsafe.Pointer)(paramSpec)), nil
+}
+
+// GetParamSpecUInt64 returns the ParamSpecUInt64 of a property of the underlying GObject.
+func (v *Object) GetParamSpecUInt64(name string) (*ParamSpecUInt64, error) {
+	cstr := C.CString(name)
+	defer C.free(unsafe.Pointer(cstr))
+
+	paramSpec := C.g_object_class_find_property(C._g_object_get_class(v.native()), (*C.gchar)(cstr))
+	if paramSpec == nil {
+		return nil, errors.New("couldn't find Property")
+	}
+
+	if Type(paramSpec.value_type) != TYPE_UINT {
+		return nil, errors.New("Wrong property type")
+	}
+
+	return ToParamSpecUInt64((unsafe.Pointer)(paramSpec)), nil
+}
+
 // GetPropertyType returns the Type of a property of the underlying GObject.
 // If the property is missing it will return TYPE_INVALID and an error.
 func (v *Object) GetPropertyType(name string) (Type, error) {

--- a/glib/gparamspectyped.go
+++ b/glib/gparamspectyped.go
@@ -1,0 +1,68 @@
+package glib
+
+//#include "glib.go.h"
+import "C"
+
+import (
+	"unsafe"
+)
+
+// ParamSpecUInt is a go representation of a C ParamSpecUInt
+type ParamSpecUInt struct{ paramSpecUInt *C.GParamSpecUInt }
+
+// ToParamSpec wraps the given pointer in a ParamSpec instance.
+func ToParamSpecUInt(paramspecuint unsafe.Pointer) *ParamSpecUInt {
+	return &ParamSpecUInt{
+		paramSpecUInt: (*C.GParamSpecUInt)(paramspecuint),
+	}
+}
+
+// Unref the underlying paramater spec.
+func (p *ParamSpecUInt) Unref() {
+	C.g_param_spec_unref((*C.GParamSpec)((unsafe.Pointer)(p.paramSpecUInt)))
+}
+
+// Minimum returns the minimum value of this parameter.
+func (p *ParamSpecUInt) Minimum() uint {
+	return (uint)(p.paramSpecUInt.minimum)
+}
+
+// Maximum returns the maximum value of this parameter.
+func (p *ParamSpecUInt) Maximum() uint {
+	return (uint)(p.paramSpecUInt.maximum)
+}
+
+// DefaultValue returns the default value of this parameter.
+func (p *ParamSpecUInt) DefaultValue() uint {
+	return (uint)(p.paramSpecUInt.default_value)
+}
+
+// ParamSpecUInt64 is a go representation of a C ParamSpecUInt64
+type ParamSpecUInt64 struct{ paramSpecUInt64 *C.GParamSpecUInt64 }
+
+// ToParamSpec64 wraps the given pointer in a ParamSpecUInt64 instance.
+func ToParamSpecUInt64(paramspecuint64 unsafe.Pointer) *ParamSpecUInt64 {
+	return &ParamSpecUInt64{
+		paramSpecUInt64: (*C.GParamSpecUInt64)(paramspecuint64),
+	}
+}
+
+// Unref the underlying paramater spec.
+func (p *ParamSpecUInt64) Unref() {
+	C.g_param_spec_unref((*C.GParamSpec)((unsafe.Pointer)(p.paramSpecUInt64)))
+}
+
+// Minimum returns the minimum value of this parameter.
+func (p *ParamSpecUInt64) Minimum() uint {
+	return (uint)(p.paramSpecUInt64.minimum)
+}
+
+// Maximum returns the maximum value of this parameter.
+func (p *ParamSpecUInt64) Maximum() uint {
+	return (uint)(p.paramSpecUInt64.maximum)
+}
+
+// DefaultValue returns the default value of this parameter.
+func (p *ParamSpecUInt64) DefaultValue() uint {
+	return (uint)(p.paramSpecUInt64.default_value)
+}


### PR DESCRIPTION
This PR adds bindings for the `ParamSpecUInt` and `ParamSpecUInt64` structures.

Please let me know if/what should I update to integrate these changes.

Thank you!